### PR TITLE
Add docker and local configuration features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 tools/**
 !tools/packages.config
 
+# Local
+.localconfig
+
 #Visual Studio Files
 [Oo]bj
 [Bb]in

--- a/.localconfig_example
+++ b/.localconfig_example
@@ -1,7 +1,7 @@
 {
 	"DatabaseName": "iValdezTest",
-	"SqlExpressConnectionString": "Data Source=localhost;Initial Catalog=iValdezTest;Integrated Security=true;",
-	"SqlExpressMasterConnectionString": "Data Source=localhost;Initial Catalog=master;Integrated Security=true;",
-	"PostgreSqlConnectionString": "Host=localhost;Username=postgres;Password=example;Database=ivaldeztest;",
-	"PostgreSqlMasterConnectionString": "Host=localhost;Username=postgres;Password=example;Database=postgres;"
+	"SqlExpressConnectionString": "Data Source=localhost,9933;Initial Catalog=iValdezTest;User Id='sa';Password='Example123'",
+	"SqlExpressMasterConnectionString": "Data Source=localhost,9933;Initial Catalog=master;User Id='sa';Password='Example123'",
+	"PostgreSqlConnectionString": "Host=localhost;Port=5432;Username='postgres';Password='example';Database=ivaldeztest;",
+	"PostgreSqlMasterConnectionString": "Host=localhost;Port=5432;Username='postgres';Password='example';Database=postgres;"
 }

--- a/.localconfig_example
+++ b/.localconfig_example
@@ -1,0 +1,7 @@
+{
+	"DatabaseName": "iValdezTest",
+	"SqlExpressConnectionString": "Data Source=localhost;Initial Catalog=iValdezTest;Integrated Security=true;",
+	"SqlExpressMasterConnectionString": "Data Source=localhost;Initial Catalog=master;Integrated Security=true;",
+	"PostgreSqlConnectionString": "Host=localhost;Username=postgres;Password=example;Database=ivaldeztest;",
+	"PostgreSqlMasterConnectionString": "Host=localhost;Username=postgres;Password=example;Database=postgres;"
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ Nuget:
 * SQL Server: https://www.nuget.org/packages/ivaldez.Sql.SqlBulkLoader/
 * PostgreSQL: https://www.nuget.org/packages/ivaldez.Sql.SqlBulkLoader.PostgreSql/
 
-## Targets
+## Development Environment Setup
+
+1. Make a copy of the file ".localconfig_example"
+1. Rename to ".localconfig"
+    1. This file contains the local configuration for the tests.
+1. A docker script is defined for the databases
+    1. Navigate to /docs/TestDatabases
+    1. run "docker compose up"
+    1. Once the docker images are running, all tests should pass when run with the default ".localconfig" file.
+
+## Package Targets
 
 * .NETFramework 4.6.1
 * .NETStandard 2.0

--- a/docs/TestDatabases/docker-compose.yml
+++ b/docs/TestDatabases/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  db_postgres:
+    image: postgres
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: example
+  db_adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+  db_sqlexpress:
+    image: mcr.microsoft.com/mssql/server
+    restart: always
+    ports:
+      - 9933:1433
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: Example123
+      MSSQL_PID:   Express

--- a/src/IntegrationPostgreSqlTests/Data/TestingDatabaseService.cs
+++ b/src/IntegrationPostgreSqlTests/Data/TestingDatabaseService.cs
@@ -33,16 +33,6 @@ namespace ivaldez.Sql.IntegrationPostgreSqlTests.Data
             }
         }
 
-        public int Insert<T>(string sql, IEnumerable<T> dtos)
-        {
-            using (var conn = new NpgsqlConnection(_connectionString))
-            {
-                var result = conn.Execute(sql, dtos);
-
-                return result;
-            }
-        }
-
         public int Execute(string sql, object param = null)
         {
             using (var conn = new NpgsqlConnection(_connectionString))

--- a/src/IntegrationPostgreSqlTests/Data/TestingDatabaseService.cs
+++ b/src/IntegrationPostgreSqlTests/Data/TestingDatabaseService.cs
@@ -2,15 +2,23 @@
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using Dapper;
+using ivaldez.Sql.SharedTestFramework;
 using Npgsql;
 
 namespace ivaldez.Sql.IntegrationPostgreSqlTests.Data
 {
     public class TestingDatabaseService
     {
-        private static readonly string DatabaseName = "iValdezTest".ToLower();
-        private readonly string _connectionString = $"Host=localhost;Username=postgres;Password=example;Database={DatabaseName};";
-        private readonly string _connectionStringMaster = $"Host=localhost;Username=postgres;Password=example;Database=postgres;";
+        public TestingDatabaseService()
+        {
+            _connectionString = LocalConfig.Instance.PostgreSqlConnectionString;
+            _connectionStringMaster = LocalConfig.Instance.PostgreSqlMasterConnectionString;
+            _databaseName = LocalConfig.Instance.DatabaseName.ToLower();
+        }
+
+        private readonly string _databaseName;
+        private readonly string _connectionString;
+        private readonly string _connectionStringMaster;
 
         public IEnumerable<T> Query<T>(string sql, object param = null)
         {
@@ -61,7 +69,7 @@ namespace ivaldez.Sql.IntegrationPostgreSqlTests.Data
             {
                 connection.Open();
                 bool result;
-                using (var command2 = new NpgsqlCommand($"SELECT 1 FROM pg_database WHERE datname='{DatabaseName}'", connection))
+                using (var command2 = new NpgsqlCommand($"SELECT 1 FROM pg_database WHERE datname='{_databaseName}'", connection))
                 {
                     result = (command2.ExecuteScalar() != null);
                 }
@@ -69,7 +77,7 @@ namespace ivaldez.Sql.IntegrationPostgreSqlTests.Data
                 if (result == false)
                 {
                     var command = connection.CreateCommand();
-                    command.CommandText = $"CREATE DATABASE {DatabaseName}";
+                    command.CommandText = $"CREATE DATABASE {_databaseName}";
                     command.ExecuteNonQuery();
                 }
             }

--- a/src/IntegrationPostgreSqlTests/IntegrationPostgreSqlTests.csproj
+++ b/src/IntegrationPostgreSqlTests/IntegrationPostgreSqlTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ivaldez.Sql.IntegrationPostgreSqlTests</RootNamespace>
     <AssemblyName>ivaldez.Sql.IntegrationPostgreSqlTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/IntegrationPostgreSqlTests/app.config
+++ b/src/IntegrationPostgreSqlTests/app.config
@@ -1,31 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.2.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/src/IntegrationPostgreSqlTests/app.config
+++ b/src/IntegrationPostgreSqlTests/app.config
@@ -1,31 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.2.0.1"/>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="4.2.0.1" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2"/>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/src/IntegrationShared/IntegrationCompatibilityTests.csproj
+++ b/src/IntegrationShared/IntegrationCompatibilityTests.csproj
@@ -10,11 +10,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ivaldez.Sql.IntegrationShared</RootNamespace>
     <AssemblyName>ivaldez.Sql.IntegrationShared</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/IntegrationShared/app.config
+++ b/src/IntegrationShared/app.config
@@ -1,27 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/src/IntegrationShared/app.config
+++ b/src/IntegrationShared/app.config
@@ -1,27 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2"/>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.2" newVersion="5.0.0.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/src/IntegrationSqlServerTests/Data/TestingDatabaseService.cs
+++ b/src/IntegrationSqlServerTests/Data/TestingDatabaseService.cs
@@ -2,14 +2,22 @@
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using Dapper;
+using ivaldez.Sql.SharedTestFramework;
 
 namespace ivaldez.Sql.IntegrationSqlServerTests.Data
 {
     public class TestingDatabaseService
     {
-        private static readonly string DatabaseName = "iValdezTest";
-        private readonly string _connectionString = $"Data Source=localhost;Initial Catalog={DatabaseName};Integrated Security=true;";
-        private readonly string _connectionStringMaster = $"Data Source=localhost;Initial Catalog=master;Integrated Security=true;";
+        public TestingDatabaseService()
+        {
+            _connectionString = LocalConfig.Instance.SqlExpressMasterConnectionString;
+            _connectionStringMaster = LocalConfig.Instance.SqlExpressMasterConnectionString;
+            _databaseName = LocalConfig.Instance.DatabaseName;
+        }
+
+        private readonly string _databaseName;
+        private readonly string _connectionString;
+        private readonly string _connectionStringMaster;
 
         public IEnumerable<T> Query<T>(string sql, object param = null)
         {
@@ -21,16 +29,6 @@ namespace ivaldez.Sql.IntegrationSqlServerTests.Data
                 {
                     yield return dto;
                 }
-            }
-        }
-
-        public int Insert<T>(string sql, IEnumerable<T> dtos)
-        {
-            using (var conn = new SqlConnection(_connectionString))
-            {
-                var result = conn.Execute(sql, dtos);
-
-                return result;
             }
         }
 
@@ -60,7 +58,7 @@ namespace ivaldez.Sql.IntegrationSqlServerTests.Data
             {
                 connection.Open();
                 bool result;
-                using (var command2 = new SqlCommand($"SELECT db_id('{DatabaseName}')", connection))
+                using (var command2 = new SqlCommand($"SELECT db_id('{_databaseName}')", connection))
                 {
                     result = (command2.ExecuteScalar() != DBNull.Value);
                 }
@@ -68,7 +66,7 @@ namespace ivaldez.Sql.IntegrationSqlServerTests.Data
                 if (result == false)
                 {
                     var command = connection.CreateCommand();
-                    command.CommandText = $"CREATE DATABASE {DatabaseName}";
+                    command.CommandText = $"CREATE DATABASE {_databaseName}";
                     command.ExecuteNonQuery();
                 }
             }

--- a/src/IntegrationSqlServerTests/Data/TestingDatabaseService.cs
+++ b/src/IntegrationSqlServerTests/Data/TestingDatabaseService.cs
@@ -10,7 +10,7 @@ namespace ivaldez.Sql.IntegrationSqlServerTests.Data
     {
         public TestingDatabaseService()
         {
-            _connectionString = LocalConfig.Instance.SqlExpressMasterConnectionString;
+            _connectionString = LocalConfig.Instance.SqlExpressConnectionString;
             _connectionStringMaster = LocalConfig.Instance.SqlExpressMasterConnectionString;
             _databaseName = LocalConfig.Instance.DatabaseName;
         }

--- a/src/IntegrationSqlServerTests/IntegrationSqlServerTests.csproj
+++ b/src/IntegrationSqlServerTests/IntegrationSqlServerTests.csproj
@@ -92,6 +92,10 @@
       <Project>{b1ed27a4-5433-4bcd-9ade-e477ccce1f03}</Project>
       <Name>ivaldez.Sql.SqlBulkLoader</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SharedTestFramework\SharedTestFramework.csproj">
+      <Project>{692D1C7C-4403-468B-B2E8-51DA8EF0C654}</Project>
+      <Name>SharedTestFramework</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/IntegrationSqlServerTests/IntegrationSqlServerTests.csproj
+++ b/src/IntegrationSqlServerTests/IntegrationSqlServerTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ivaldez.Sql.IntegrationSqlServerTests</RootNamespace>
     <AssemblyName>ivaldez.Sql.IntegrationSqlServerTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/SharedTestFramework/LocalConfig.cs
+++ b/src/SharedTestFramework/LocalConfig.cs
@@ -16,7 +16,7 @@ namespace ivaldez.Sql.SharedTestFramework
                 {
                     if (_instance == null)
                     {
-                        var path = TestUtilities.AssemblyDirectory + @"\..\..\..\..\.localconfig";
+                        var path = Path.Combine(TestUtilities.AssemblyDirectory, @".localconfig");
 
                         _instance = TestUtilities.DeserializeFile<LocalConfig>(path);
                     }

--- a/src/SharedTestFramework/LocalConfig.cs
+++ b/src/SharedTestFramework/LocalConfig.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+
+namespace ivaldez.Sql.SharedTestFramework
+{
+    public class LocalConfig
+    {
+        private static object lockObject = new object();
+        private static LocalConfig _instance;
+
+        public static LocalConfig Instance
+        {
+            get
+            {
+                lock (lockObject)
+                {
+                    if (_instance == null)
+                    {
+                        var path = TestUtilities.AssemblyDirectory + @"\..\..\..\..\.localconfig";
+
+                        _instance = TestUtilities.DeserializeFile<LocalConfig>(path);
+                    }
+
+                    return _instance;
+                }
+            }
+        }
+
+        public string DatabaseName { get; set; }
+        public string SqlExpressConnectionString { get; set; }
+        public string SqlExpressMasterConnectionString { get; set; }
+        public string PostgreSqlConnectionString { get; set; }
+        public string PostgreSqlMasterConnectionString { get; set; }
+    }
+}

--- a/src/SharedTestFramework/SharedTestFramework.csproj
+++ b/src/SharedTestFramework/SharedTestFramework.csproj
@@ -51,6 +51,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\.localconfig">
+      <Link>.localconfig</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/SharedTestFramework/SharedTestFramework.csproj
+++ b/src/SharedTestFramework/SharedTestFramework.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ivaldez.Sql.SharedTestFramework</RootNamespace>
     <AssemblyName>ivaldez.Sql.SharedTestFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/SharedTestFramework/SharedTestFramework.csproj
+++ b/src/SharedTestFramework/SharedTestFramework.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -42,8 +45,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestUtilities.cs" />
     <Compile Include="ImplementationSpecificTestAttribute.cs" />
+    <Compile Include="LocalConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/SharedTestFramework/TestUtilities.cs
+++ b/src/SharedTestFramework/TestUtilities.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace ivaldez.Sql.SharedTestFramework
+{
+    public class TestUtilities
+    {
+        public static string AssemblyDirectory
+        {
+            get
+            {
+                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+                UriBuilder uri = new UriBuilder(codeBase);
+                string path = Uri.UnescapeDataString(uri.Path);
+                return Path.GetDirectoryName(path);
+            }
+        }
+
+        public static T DeserializeFile<T>(string file)
+        {
+            var path = TestUtilities.AssemblyDirectory + @"\..\..\..\..\.localconfig";
+
+            var json = File.ReadAllText(path);
+
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+    }
+}

--- a/src/SharedTestFramework/TestUtilities.cs
+++ b/src/SharedTestFramework/TestUtilities.cs
@@ -20,9 +20,7 @@ namespace ivaldez.Sql.SharedTestFramework
 
         public static T DeserializeFile<T>(string file)
         {
-            var path = TestUtilities.AssemblyDirectory + @"\..\..\..\..\.localconfig";
-
-            var json = File.ReadAllText(path);
+            var json = File.ReadAllText(file);
 
             return JsonConvert.DeserializeObject<T>(json);
         }

--- a/src/SharedTestFramework/packages.config
+++ b/src/SharedTestFramework/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+</packages>

--- a/src/ivaldez.SqlBulkLoader.PostgreSql/ivaldez.Sql.SqlBulkLoader.PostgreSql.csproj
+++ b/src/ivaldez.SqlBulkLoader.PostgreSql/ivaldez.Sql.SqlBulkLoader.PostgreSql.csproj
@@ -10,8 +10,8 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Description>A convention based wrapper around the PostgreSQL binary COPY feature for bulk loading data.</Description>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>1.0.0.8-rc1</Version>
-    <AssemblyVersion>1.0.0.8</AssemblyVersion>
+    <Version>1.0.0.0</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Jason Valdez</Authors>
     <Company>ivaldez</Company>
     <RepositoryUrl>https://github.com/JasonDV/SQLBulkLoader</RepositoryUrl>

--- a/src/ivaldez.SqlBulkLoader/ivaldez.Sql.SqlBulkLoader.csproj
+++ b/src/ivaldez.SqlBulkLoader/ivaldez.Sql.SqlBulkLoader.csproj
@@ -10,8 +10,8 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Description>A convention based wrapper around the SqlBulkCopy utility.</Description>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>1.0.0.8-rc1</Version>
-    <AssemblyVersion>1.0.0.8</AssemblyVersion>
+    <Version>1.0.0.0</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Jason Valdez</Authors>
     <Company>ivaldez</Company>
     <RepositoryUrl>https://github.com/JasonDV/SQLBulkLoader</RepositoryUrl>


### PR DESCRIPTION
This commit will add a standard docker compose script that is compatible with the default configuration for the tests. This makes the local configuration more portable. 

The ".localconfig" file is a custom solution based on what I've seen done in some other projects. The idea here is that we don't want to force developers to have to match a local configuration just to run the build and tests. This allows developers to provide connection information for existing databases if the have them or they can use the default configuration with the docker scripts. 